### PR TITLE
Fixed file not found error on cleanup

### DIFF
--- a/providers/file.js
+++ b/providers/file.js
@@ -6,7 +6,7 @@ class LocalProvider extends Provider {
   static upload(file, dir) {
     const localDir = `${uploadDir}/${dir}`;
     return fs.ensureDir(localDir).then(() => {
-      return fs.move(file.path, `${localDir}/${file.filename}`).then(() => {
+      return fs.copy(file.path, `${localDir}/${file.filename}`).then(() => {
         file.url = '/' + encodeURIComponent(`${dir}/${file.filename}`);
         return file;
       });


### PR DESCRIPTION
When using file provider, once the file is uploaded it is then moved from the `tmp` directory to the local directory.  This causes an unhandled error once the cleanup method is called as it tries to delete the file in the `tmp` directory which was previously moved.

![image](https://user-images.githubusercontent.com/9391489/83960950-89c3f580-a85c-11ea-8805-5cbcf17b184b.png)

